### PR TITLE
Fix md indent and mmp empty box

### DIFF
--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -293,7 +293,9 @@ export default class Node {
 
     cancelEdit(){
         var text = this.contentEl.innerText.trim()||'';
+        if(text.length == 0){
             text = this._oldText
+        }
         this.data.text = text;
         this.contentEl.innerText = '';
         

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -109,7 +109,9 @@ export default class Node {
     }
 
     parseText(){
-       
+        if (this.data.text.length === 0){
+            this.data.text = "Sub title";
+        }
         MarkdownRenderer.renderMarkdown( this.data.text ,this.contentEl,this.mindmap.path||"",null).then(()=>{
             this.data.mdText = this.contentEl.innerHTML;
             this.refreshBox();
@@ -291,6 +293,7 @@ export default class Node {
 
     cancelEdit(){
         var text = this.contentEl.innerText.trim()||'';
+            text = this._oldText
         this.data.text = text;
         this.contentEl.innerText = '';
         

--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -1131,7 +1131,7 @@ export default class MindMap {
 
             } else {
                 for (var i = 0; i < n.getLevel() - level; i++) {
-                    space += '   ';
+                    space += '\t';
                 }
                 var text = n.getData().text.trim();
                 if (text) {
@@ -1153,10 +1153,14 @@ export default class MindMap {
                             //text
                             md += `${space}- `;
                             textArr.forEach((t: string, i: number) => {
+                                var contentText = "void";
+                                if(t.trim().length > 0){
+                                    contentText = t.trim();
+                                }
                                 if (i > 0) {
-                                    md += `${space}   ${t.trim()}${i === textArr.length - 1 ? ending : '' }\n`
+                                    md += `${space}${contentText}${i === textArr.length - 1 ? ending : '' }\n`
                                 } else {
-                                    md += `${t.trim()}\n`
+                                    md += `${contentText}\n`
                                 }
                             });
                         }
@@ -1164,7 +1168,7 @@ export default class MindMap {
                     }
                 } else {
                     for (var i = 0; i < n.getLevel() - level; i++) {
-                        space += '   ';
+                        space += '\t';
                     }
                     md += `${space}-\n`;
                 }


### PR DESCRIPTION
In this pull request：
- I change the indent used in markdown file from 3 spaces to a '\t'
- prevent the mindmap box become an empty box by having a check of the length of the text within.