### PR TITLE
integrate #139 feature to #139 keyboard shortcut

### DIFF
--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -530,28 +530,28 @@ export default class MindMap {
             if (keyCode == 38 || e.key == 'ArrowUp') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._hierarcySelectNode(node, "up");
+                    this._selectNode(node, "up");
                 }
             }
 
             if (keyCode == 40 || e.key == 'ArrowDown') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._hierarcySelectNode(node, "down");
+                    this._selectNode(node, "down");
                 }
             }
 
             if (keyCode == 39 || e.key == 'ArrowRight') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._hierarcySelectNode(node, "right");
+                    this._selectNode(node, "right");
                 }
             }
 
             if (keyCode == 37 || e.key == 'ArrowLeft') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._hierarcySelectNode(node, "left");
+                    this._selectNode(node, "left");
                 }
             }
 
@@ -587,7 +587,7 @@ export default class MindMap {
             if (keyCode == 38 || e.key == 'ArrowUp') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._selectNode(node, "up");
+                    this._hierarchySelectNode(node, "up");
                     this.center(this.selectNode);
                 } else if(!node){
                     this.center(this.lastSelectedNode);
@@ -597,7 +597,7 @@ export default class MindMap {
             if (keyCode == 40 || e.key == 'ArrowDown') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._selectNode(node, "down");
+                    this._hierarchySelectNode(node, "down");
                     this.center(this.selectNode)
                 }else if(!node){
                     this.center(this.lastSelectedNode);
@@ -607,7 +607,7 @@ export default class MindMap {
             if (keyCode == 39 || e.key == 'ArrowRight') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._selectNode(node, "right");
+                    this._hierarchySelectNode(node, "right");
                     this.center(this.selectNode)
                 }else if(!node){
                     this.center(this.lastSelectedNode);
@@ -617,7 +617,7 @@ export default class MindMap {
             if (keyCode == 37 || e.key == 'ArrowLeft') {
                 var node = this.selectNode;
                 if (node && !node.isEdit) {
-                    this._selectNode(node, "left");
+                    this._hierarchySelectNode(node, "left");
                     this.center(this.selectNode)
                 }else if(!node){
                     this.center(this.lastSelectedNode);
@@ -626,7 +626,7 @@ export default class MindMap {
             /* end here */
         }
     }
-    _hierarcySelectNode(node: INode, direct: string){
+    _hierarchySelectNode(node: INode, direct: string){
         if (!node) {
             return;
         }

--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -356,8 +356,10 @@ export default class MindMap {
         this.view?.mindMapChange();
     }
     appFocusIn(evt: FocusEvent){
-        if (this.containerEL.contains(evt.relatedTarget as Node)) return;
-        this.isFocused = true;
+        setTimeout(() => {
+            if (this.containerEL.contains(evt.relatedTarget as Node)) return;
+            this.isFocused = true;
+        }, 100);
     }
     appFocusOut(evt: FocusEvent){
         if (this.containerEL.contains(evt.relatedTarget as Node)) return;

--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -577,6 +577,8 @@ export default class MindMap {
 
             // ctrl + E  center to root
             if (keyCode == 69) {
+                var node = this.selectNode;
+                if (node && node.isEdit) return;
                 this.center(this.root);
             }
 


### PR DESCRIPTION
finalize feature from #138 & #139 

final changelog
- added keyboard shortcut `ctrl + arrow-up|down|left|right` to navigate between node and center the node
- `ctrl + arrow-up|down|left|right` when no selected node, focus to last selected node
- navigate with `ctrl + arrow-up|down|left|right` behave differently than navigate with `arrow-up|down|left|right`