### PR TITLE
Minor adjustments

### DIFF
--- a/main.js
+++ b/main.js
@@ -390,7 +390,7 @@ function keepLastIndex(dom) {
         range.collapseToEnd();
     }
     // else if ( document.selection ) { //ie10 9 8 7 6 5
-    //     var range = document.selection.createRange(); 
+    //     var range = document.selection.createRange();
     //     range.moveToElementText(dom);
     //     range.collapse(false);
     //     range.select();
@@ -406,9 +406,10 @@ class Node {
         };
         this.isExpand = true;
         this.isSelect = false;
+        //isRoot?:boolean;
         this.children = [];
         this.isHide = false;
-        this.isEdit = false;
+        //isEdit:boolean=false;
         this._barDom = null;
         this.data = data;
         this.mindmap = mindMap;
@@ -431,10 +432,10 @@ class Node {
         this.initNodeBar();
         if (this.data.isRoot) {
             this.containEl.classList.add('mm-root');
-            this.isRoot = true;
+            this.data.isRoot = true;
         }
         else {
-            this.isRoot = false;
+            this.data.isRoot = false;
             this.containEl.classList.remove('mm-root');
         }
         this.parseText();
@@ -533,7 +534,7 @@ class Node {
                     el.addClasses(["image-embed", "is-loaded"]);
                 }
             });
-            //Possible causes of delay,code mathjax  
+            //Possible causes of delay,code mathjax
             var dom = this.contentEl.querySelector('code') || this.contentEl.querySelector('.MathJax');
             if (dom) {
                 setTimeout(() => {
@@ -542,7 +543,7 @@ class Node {
                     this.mindmap && this.mindmap.emit('renderEditNode', {});
                 }, 100);
             }
-            //image 
+            //image
             this.contentEl.querySelectorAll('img').forEach(element => {
                 element.onload = () => {
                     this.clearCacheData();
@@ -561,7 +562,9 @@ class Node {
     select() {
         this.isSelect = true;
         this.containEl.setAttribute('draggable', 'true');
+        //if(this.mindmap.view.plugin.settings.focusOnMove) {
         this.containEl.focus(); // set the dom to be focused
+        //}
         Object.assign(window, {
             myNode: this
         });
@@ -587,7 +590,7 @@ class Node {
         this.contentEl.setAttribute('contentEditable', 'true');
         this.contentEl.focus();
         this.mindmap.editNode = this;
-        this.isEdit = true;
+        this.data.isEdit = true;
         keepLastIndex(this.contentEl);
         if (this.contentEl.innerText == t('Sub title')) {
             this.selectText();
@@ -602,7 +605,7 @@ class Node {
         //     var range = document.body.createTextRange();
         //     range.moveToElementText(text);
         //     range.select();
-        // } 
+        // }
         if (window.getSelection) {
             var selection = window.getSelection();
             var range = document.createRange();
@@ -729,26 +732,25 @@ class Node {
             });
         }
         this.contentEl.setAttribute('contentEditable', 'false');
-        this.isEdit = false;
+        this.data.isEdit = false;
         if (this.containEl.classList.contains('mm-edit-node')) {
             this.containEl.classList.remove('mm-edit-node');
         }
     }
     getLevel() {
         var level = 0, parent = this.parent;
-        if (this == this.mindmap.root) {
-            return level;
-        }
-        level++;
-        while (parent && parent != this.mindmap.root) {
+        if (!this.data.isRoot) {
             level++;
-            parent = parent.parent;
+            while (parent && parent != this.mindmap.root) {
+                level++;
+                parent = parent.parent;
+            }
         }
         return level;
     }
     getIndex() {
         var l_index = 0;
-        if (!this.isRoot) {
+        if (!this.data.isRoot) {
             l_index = this.parent.children.indexOf(this);
         }
         return l_index;
@@ -7744,7 +7746,7 @@ class RemoveNode extends Command {
         this.mind = mind || this.node.mindmap;
     }
     execute() {
-        if (this.node.isRoot == true) {
+        if (this.node.data.isRoot == true) {
             return false;
         }
         this.node.clearCacheData();
@@ -8418,7 +8420,7 @@ class MindMap {
             if (isRoot) {
                 n.setPosition(x, y);
                 that.root = n;
-                n.isRoot = true;
+                n.data.isRoot = true;
             }
             else {
                 n.setPosition(0, 0);
@@ -8489,7 +8491,7 @@ class MindMap {
             this.selectNode = null;
         }
         if (this.editNode) {
-            if (this.editNode.isEdit) {
+            if (this.editNode.data.isEdit) {
                 this.editNode.cancelEdit();
             }
             this.editNode = null;
@@ -8507,7 +8509,7 @@ class MindMap {
         //     this.selectNode = null
         // }
         // if (this.editNode) {
-        //     if(this.editNode.isEdit){
+        //     if(this.editNode.data.isEdit){
         //         this.editNode.cancelEdit();
         //     }
         //     this.editNode = null;
@@ -8567,7 +8569,7 @@ class MindMap {
         //console.log(this._nodeNum,this._tempNum);
         if (this._tempNum == this._nodeNum) {
             this.refresh();
-            this.center();
+            //this.center();
         }
     }
     renderEditNode(evt) {
@@ -8604,7 +8606,7 @@ class MindMap {
         //     if (keyCode == 113) {
         //     // if (keyCode == 45) {
         //         var node = this.selectNode;
-        //         if (node && !node.isEdit) {
+        //         if (node && !node.data.isEdit) {
         //             e.preventDefault();
         //             e.stopPropagation();
         //             if (!node.isExpand) {
@@ -8645,7 +8647,7 @@ class MindMap {
             //     e.preventDefault();
             //     e.stopPropagation();
             //     if(node) {// A node is selected
-            //         if (!node.isEdit) {// Not editing a node => Add sibling node
+            //         if (!node.data.isEdit) {// Not editing a node => Add sibling node
             //             if (!node.isExpand) {
             //                 node.expand();
             //             }
@@ -8668,7 +8670,7 @@ class MindMap {
             //delete
             // if (keyCode == 46 || e.key == 'Delete' || e.key == 'Backspace') {
             //     var node = this.selectNode;
-            //     if (node && !node.isRoot && !node.isEdit) {
+            //     if (node && !node.data.isRoot && !node.data.isEdit) {
             //         e.preventDefault();
             //         e.stopPropagation();
             //         node.mindmap.execute("deleteNodeAndChild", { node });
@@ -8682,7 +8684,7 @@ class MindMap {
             //     e.stopPropagation();
             //     var node = this.selectNode;
             //     if(node) {
-            //         if (!node.isEdit) {// Not editing
+            //         if (!node.data.isEdit) {// Not editing
             //             if (!node.isExpand) {
             //                 node.expand();
             //             }
@@ -8702,7 +8704,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 var node = this.selectNode;
-                if (node && node.isEdit) {
+                if (node && node.data.isEdit) {
                     node.select();
                     node.mindmap.editNode = null;
                     node.cancelEdit();
@@ -8715,7 +8717,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var l_selectedNode = node;
                     while ((this.selectNode == node) &&
                         (l_selectedNode != this.root)) {
@@ -8728,7 +8730,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var l_selectedNode = node;
                     while ((this.selectNode == node) &&
                         (l_selectedNode != this.root)) {
@@ -8741,7 +8743,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var rootPos = this.root.getPosition();
                     var nodePos = node.getPosition();
                     if (rootPos.x > nodePos.x) { // Node on left side of the mindmap
@@ -8761,7 +8763,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var rootPos = this.root.getPosition();
                     var nodePos = node.getPosition();
                     if (rootPos.x < nodePos.x) { // Node on right side of the mindmap
@@ -8782,7 +8784,7 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 if ((!this.selectNode) ||
-                    (!this.selectNode.isEdit)) { // No edition: select root node
+                    (!this.selectNode.data.isEdit)) { // No edition: select root node
                     if (this.selectNode) {
                         this.selectNode.unSelect();
                     }
@@ -8799,7 +8801,7 @@ class MindMap {
             // }
             if ((keyCode == 191) || (keyCode == 111)) {
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     if (node.isExpand) {
                         node.mindmap.execute('collapseNode', {
                             node
@@ -8819,7 +8821,7 @@ class MindMap {
             //         var l_prefix_1 = "**";
             //         var l_prefix_2 = "__";
             //         var node = this.selectNode;
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in bold only the selected part
             //             var l_check_prefix = true;
             //             node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -8841,7 +8843,7 @@ class MindMap {
             //     e.stopPropagation();
             //     if(this.selectNode) {
             //         var node = this.selectNode;
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in italics only the selected part
             //             node.setSelectedText_italic();
             //         }
@@ -8894,8 +8896,8 @@ class MindMap {
             //         this.root.select();
             //         node = this.selectNode;
             //     }
-            //     else if((!node.isEdit)  &&
-            //             (!node.isRoot)  )
+            //     else if((!node.data.isEdit)  &&
+            //             (!node.data.isRoot)  )
             //     {// The node can be moved
             //         var type='top';
             //         if(node.getIndex() == 0)
@@ -8917,8 +8919,8 @@ class MindMap {
             //         this.root.select();
             //         node = this.selectNode;
             //     }
-            //     else if((!node.isEdit)  &&
-            //             (!node.isRoot)  )
+            //     else if((!node.data.isEdit)  &&
+            //             (!node.data.isRoot)  )
             //     {// The node can be moved
             //         var type='down';
             //         if(node.getIndex() == node.parent.children.length-1)
@@ -8995,8 +8997,8 @@ class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
                 if ((!this.selectNode) ||
-                    (!this.selectNode.isEdit)) { // No edition: select root node
-                    if (this.selectNode && !this.selectNode.isRoot) {
+                    (!this.selectNode.data.isEdit)) { // No edition: select root node
+                    if (this.selectNode && !this.selectNode.data.isRoot) {
                         this.selectNode.unSelect();
                         this.root.select();
                     }
@@ -9181,22 +9183,22 @@ class MindMap {
         node.select();
     }
     _moveAsParent(node) {
-        if ((!node.isEdit) &&
-            (!node.isRoot) &&
+        if ((!node.data.isEdit) &&
+            (!node.data.isRoot) &&
             (node.getLevel() > 1)) { // The node can be moved
             this.moveNode(node, node.parent, 'down');
         }
         return;
     }
     _moveAsChild(movedNode, newParentNode) {
-        if ((!movedNode.isEdit) &&
-            (!movedNode.isRoot)) { // The node can be moved
+        if ((!movedNode.data.isEdit) &&
+            (!movedNode.data.isRoot)) { // The node can be moved
             this.moveNode(movedNode, newParentNode, 'child-right');
         }
         return;
     }
     _toggleExpandNode(node) {
-        if (node && !node.isEdit) {
+        if (node && !node.data.isEdit) {
             if (node.isExpand) {
                 node.mindmap.execute('collapseNode', {
                     node
@@ -9363,7 +9365,7 @@ class MindMap {
                 }
                 if (targetEl.closest('.mm-icon-delete-node')) {
                     var selectNode = this.selectNode;
-                    if (!node.isRoot && selectNode) {
+                    if (!node.data.isRoot && selectNode) {
                         selectNode.mindmap.execute("deleteNodeAndChild", { node: selectNode });
                         this._menuDom.style.display = 'none';
                     }
@@ -9505,7 +9507,7 @@ class MindMap {
                 evt.preventDefault();
                 var dropNodeId = evt.target.closest('.mm-node').getAttribute('data-id');
                 var dropNode = this.getNodeById(dropNodeId);
-                if (this._dragNode.isRoot) ;
+                if (this._dragNode.data.isRoot) ;
                 else {
                     this.moveNode(this._dragNode, dropNode, this._dragType);
                 }
@@ -9696,7 +9698,7 @@ class MindMap {
         return box;
     }
     moveNode(dragNode, dropNode, type, setInHistory = true) {
-        if (dragNode == dropNode || dragNode.isRoot) {
+        if (dragNode == dropNode || dragNode.data.isRoot) {
             return;
         }
         var flag = false;
@@ -9806,6 +9808,9 @@ class MindMap {
     layout() {
         if (!this.mmLayout) {
             this.mmLayout = new Layout(this.root, this.setting.layoutDirect || 'mind map', this.colors);
+            // Select and center on the mindmap's root when opening it
+            this.root.select();
+            this.centerOnNode(this.root);
             return;
         }
         this.mmLayout.layout(this.root, this.setting.layoutDirect || this.mmLayout.direct || 'mind map');
@@ -9856,7 +9861,8 @@ class MindMap {
             //this.containerEL.scrollTop = this.setting.canvasSize / 2 - h / 2 - 60 ;
             //this.containerEL.scrollLeft = this.setting.canvasSize / 2 - w / 2 + 30 ;
             this.containerEL.scrollTop = pos_y - (h / 2 - dim_y / 2) + 90;
-            this.containerEL.scrollLeft = pos_x - (w / 2 - dim_x / 2) + 40;
+            //this.containerEL.scrollLeft = pos_x - (w/2 - dim_x/2) + 40;
+            this.containerEL.scrollLeft = pos_x - (w / 2 - dim_x / 2) + 200;
             this.scale(oldScale);
         }
     }
@@ -38518,6 +38524,14 @@ class MindMapSettingsTab extends obsidian.PluginSettingTab {
                 });
             });
         });
+        new obsidian.Setting(containerEl)
+            .setName('Display moved on current node')
+            .setDesc('If enabled, the mindmap view is centered on the current node when moving it')
+            .addToggle((toggle) => toggle
+            .setValue(this.plugin.settings.focusOnMove).onChange((value) => {
+            this.plugin.settings.focusOnMove = value;
+            this.plugin.saveData(this.plugin.settings);
+        }));
     }
 }
 
@@ -38678,7 +38692,7 @@ class MindMapPlugin extends obsidian.Plugin {
                     if (mindmapView) {
                         var mindmap = mindmapView.mindmap;
                         var node = mindmap.selectNode;
-                        if (node && !node.isEdit) {
+                        if (node && !node.data.isEdit) {
                             node.edit();
                             mindmap._menuDom.style.display = 'none';
                         }
@@ -38701,7 +38715,7 @@ class MindMapPlugin extends obsidian.Plugin {
                         var mindmap = mindmapView.mindmap;
                         var node = mindmap.selectNode;
                         if (node) { // A node is selected
-                            if (!node.isEdit) { // Not editing a node => Add sibling node
+                            if (!node.data.isEdit) { // Not editing a node => Add sibling node
                                 // if (!node.isExpand) {
                                 //   node.expand();
                                 // }
@@ -38742,7 +38756,7 @@ class MindMapPlugin extends obsidian.Plugin {
                         var mindmap = mindmapView.mindmap;
                         var node = mindmap.selectNode;
                         if (node) {
-                            if (!node.isEdit) { // Not editing
+                            if (!node.data.isEdit) { // Not editing
                                 if (!node.isExpand) {
                                     node.expand();
                                 }
@@ -38775,7 +38789,7 @@ class MindMapPlugin extends obsidian.Plugin {
                     if (mindmapView) {
                         var mindmap = mindmapView.mindmap;
                         var node = mindmap.selectNode;
-                        if (node && !node.isRoot && !node.isEdit) {
+                        if (node && !node.data.isRoot && !node.data.isEdit) {
                             node.mindmap.execute("deleteNodeAndChild", { node });
                             mindmap._menuDom.style.display = 'none';
                         }
@@ -38818,7 +38832,7 @@ class MindMapPlugin extends obsidian.Plugin {
                             var l_prefix_1 = "**"; // Applied prefix
                             var l_prefix_2 = "__"; // Alternate prefix to look for
                             var node = mindmap.selectNode;
-                            if (node.isEdit) { // A node is edited: set in bold only the selected part
+                            if (node.data.isEdit) { // A node is edited: set in bold only the selected part
                                 var l_check_prefix = true;
                                 node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
                             }
@@ -38848,7 +38862,7 @@ class MindMapPlugin extends obsidian.Plugin {
                         var mindmap = mindmapView.mindmap;
                         if (mindmap.selectNode) {
                             var node = mindmap.selectNode;
-                            if (node.isEdit) { // A node is edited: set in italics only the selected part
+                            if (node.data.isEdit) { // A node is edited: set in italics only the selected part
                                 node.setSelectedText_italic();
                             }
                             else { // Set in italics the whole node
@@ -38899,7 +38913,7 @@ class MindMapPlugin extends obsidian.Plugin {
                             var l_prefix_1 = "==";
                             var l_prefix_2 = l_prefix_1;
                             var node = mindmap.selectNode;
-                            if (node.isEdit) { // A node is edited: set in bold only the selected part
+                            if (node.data.isEdit) { // A node is edited: set in bold only the selected part
                                 var l_check_prefix = true;
                                 node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
                             }
@@ -38923,7 +38937,7 @@ class MindMapPlugin extends obsidian.Plugin {
                             var l_prefix_1 = "~~";
                             var l_prefix_2 = l_prefix_1;
                             var node = mindmap.selectNode;
-                            if (node.isEdit) { // A node is edited: set in bold only the selected part
+                            if (node.data.isEdit) { // A node is edited: set in bold only the selected part
                                 var l_check_prefix = true;
                                 node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
                             }
@@ -38944,7 +38958,7 @@ class MindMapPlugin extends obsidian.Plugin {
                     if (mindmapView) {
                         var mindmap = mindmapView.mindmap;
                         var node = mindmap.selectNode;
-                        if (node && node.isEdit) {
+                        if (node && node.data.isEdit) {
                             node.select();
                             node.mindmap.editNode = null;
                             node.cancelEdit();
@@ -39087,8 +39101,8 @@ class MindMapPlugin extends obsidian.Plugin {
                             mindmap.root.select();
                             node = mindmap.selectNode;
                         }
-                        else if ((!node.isEdit) &&
-                            (!node.isRoot)) { // The node can be moved
+                        else if ((!node.data.isEdit) &&
+                            (!node.data.isRoot)) { // The node can be moved
                             var type = 'top';
                             if (node.getIndex() == 0) { // First sibling: move BELOW "previous" (=last) node
                                 type = 'down';
@@ -39096,7 +39110,9 @@ class MindMapPlugin extends obsidian.Plugin {
                             //else: no special treatment
                             mindmap.moveNode(node, node.getPreviousSibling(), type);
                         }
-                        mindmap.centerOnNode(mindmap.selectNode);
+                        if ((this.settings.focusOnMove == true)) {
+                            mindmap.centerOnNode(mindmap.selectNode);
+                        }
                     }
                 }
             });
@@ -39119,8 +39135,8 @@ class MindMapPlugin extends obsidian.Plugin {
                             mindmap.root.select();
                             node = mindmap.selectNode;
                         }
-                        else if ((!node.isEdit) &&
-                            (!node.isRoot)) { // The node can be moved
+                        else if ((!node.data.isEdit) &&
+                            (!node.data.isRoot)) { // The node can be moved
                             var type = 'down';
                             if (node.getIndex() == node.parent.children.length - 1) { // Last sibling: move ABOVE "next" (=first) node
                                 type = 'top';
@@ -39128,7 +39144,9 @@ class MindMapPlugin extends obsidian.Plugin {
                             //else: no special treatment
                             mindmap.moveNode(node, node.getNextSibling(), type);
                         }
-                        mindmap.centerOnNode(mindmap.selectNode);
+                        if ((this.settings.focusOnMove == true)) {
+                            mindmap.centerOnNode(mindmap.selectNode);
+                        }
                     }
                 }
             });
@@ -39161,7 +39179,9 @@ class MindMapPlugin extends obsidian.Plugin {
                                 mindmap._moveAsChild(node, node.getPreviousSibling());
                             }
                         }
-                        mindmap.centerOnNode(mindmap.selectNode);
+                        if ((this.settings.focusOnMove == true)) {
+                            mindmap.centerOnNode(mindmap.selectNode);
+                        }
                     }
                 }
             });
@@ -39197,7 +39217,9 @@ class MindMapPlugin extends obsidian.Plugin {
                                 mindmap._moveAsParent(node);
                             }
                         }
-                        mindmap.centerOnNode(mindmap.selectNode);
+                        if ((this.settings.focusOnMove == true)) {
+                            mindmap.centerOnNode(mindmap.selectNode);
+                        }
                     }
                 }
             });

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ export default class MindMapPlugin extends Plugin {
         if(mindmapView){
           var mindmap = mindmapView.mindmap;
           var node = mindmap.selectNode;
-          if (node && !node.isEdit) {
+          if (node && !node.data.isEdit) {
             node.edit();
             mindmap._menuDom.style.display = 'none';
           }
@@ -209,7 +209,7 @@ export default class MindMapPlugin extends Plugin {
           var mindmap = mindmapView.mindmap;
           var node = mindmap.selectNode;
           if(node) {// A node is selected
-            if (!node.isEdit) {// Not editing a node => Add sibling node
+            if (!node.data.isEdit) {// Not editing a node => Add sibling node
               // if (!node.isExpand) {
               //   node.expand();
               // }
@@ -252,7 +252,7 @@ export default class MindMapPlugin extends Plugin {
           var mindmap = mindmapView.mindmap;
           var node = mindmap.selectNode;
           if(node) {
-            if (!node.isEdit) {// Not editing
+            if (!node.data.isEdit) {// Not editing
               if (!node.isExpand) {
                 node.expand();
               }
@@ -285,7 +285,7 @@ export default class MindMapPlugin extends Plugin {
         if(mindmapView){
           var mindmap = mindmapView.mindmap;
           var node = mindmap.selectNode;
-          if (node && !node.isRoot && !node.isEdit) {
+          if (node && !node.data.isRoot && !node.data.isEdit) {
             node.mindmap.execute("deleteNodeAndChild", { node });
             mindmap._menuDom.style.display='none';
           }
@@ -331,7 +331,7 @@ export default class MindMapPlugin extends Plugin {
             var l_prefix_2 = "__"; // Alternate prefix to look for
             var node = mindmap.selectNode;
 
-            if(node.isEdit)
+            if(node.data.isEdit)
             {// A node is edited: set in bold only the selected part
               var l_check_prefix = true;
               node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -367,7 +367,7 @@ export default class MindMapPlugin extends Plugin {
           if(mindmap.selectNode) {
             var node = mindmap.selectNode;
 
-            if(node.isEdit)
+            if(node.data.isEdit)
             {// A node is edited: set in italics only the selected part
               node.setSelectedText_italic();
             }
@@ -428,7 +428,7 @@ export default class MindMapPlugin extends Plugin {
             var l_prefix_2 = l_prefix_1;
             var node = mindmap.selectNode;
 
-            if(node.isEdit)
+            if(node.data.isEdit)
             {// A node is edited: set in bold only the selected part
               var l_check_prefix = true;
               node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -457,7 +457,7 @@ export default class MindMapPlugin extends Plugin {
             var l_prefix_2 = l_prefix_1;
             var node = mindmap.selectNode;
 
-            if(node.isEdit)
+            if(node.data.isEdit)
             {// A node is edited: set in bold only the selected part
               var l_check_prefix = true;
               node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -482,7 +482,7 @@ export default class MindMapPlugin extends Plugin {
         if(mindmapView){
           var mindmap = mindmapView.mindmap;
           var node = mindmap.selectNode;
-          if (node && node.isEdit) {
+          if (node && node.data.isEdit) {
             node.select();
             node.mindmap.editNode = null;
             node.cancelEdit();
@@ -633,8 +633,8 @@ export default class MindMapPlugin extends Plugin {
             mindmap.root.select();
             node = mindmap.selectNode;
           }
-          else if((!node.isEdit)  &&
-                  (!node.isRoot)  )
+          else if((!node.data.isEdit)  &&
+                  (!node.data.isRoot)  )
           {// The node can be moved
             var type='top';
             if(node.getIndex() == 0)
@@ -644,7 +644,10 @@ export default class MindMapPlugin extends Plugin {
             //else: no special treatment
             mindmap.moveNode(node, node.getPreviousSibling(), type);
           }
-          mindmap.centerOnNode(mindmap.selectNode);
+          if ((this.settings.focusOnMove == true))
+          {
+            mindmap.centerOnNode(mindmap.selectNode);
+          }
         }
       }
     });
@@ -669,8 +672,8 @@ export default class MindMapPlugin extends Plugin {
             mindmap.root.select();
             node = mindmap.selectNode;
           }
-          else if((!node.isEdit)  &&
-                  (!node.isRoot)  )
+          else if((!node.data.isEdit)  &&
+                  (!node.data.isRoot)  )
           {// The node can be moved
             var type='down';
             if(node.getIndex() == node.parent.children.length-1)
@@ -680,7 +683,10 @@ export default class MindMapPlugin extends Plugin {
             //else: no special treatment
             mindmap.moveNode(node, node.getNextSibling(), type);
           }
-          mindmap.centerOnNode(mindmap.selectNode);
+          if((this.settings.focusOnMove == true))
+            {
+            mindmap.centerOnNode(mindmap.selectNode);
+          }
         }
       }
     });
@@ -717,7 +723,10 @@ export default class MindMapPlugin extends Plugin {
               mindmap._moveAsChild(node, node.getPreviousSibling());
             }
           }
-          mindmap.centerOnNode(mindmap.selectNode);
+          if((this.settings.focusOnMove == true))
+            {
+            mindmap.centerOnNode(mindmap.selectNode);
+          }
         }
       }
     });
@@ -757,7 +766,10 @@ export default class MindMapPlugin extends Plugin {
               mindmap._moveAsParent(node);
             }
           }
-          mindmap.centerOnNode(mindmap.selectNode);
+          if((this.settings.focusOnMove == true))
+            {
+            mindmap.centerOnNode(mindmap.selectNode);
+          }
         }
       }
     });

--- a/src/mindmap/Cmds.ts
+++ b/src/mindmap/Cmds.ts
@@ -72,7 +72,7 @@ export class RemoveNode extends Command {
         this.mind = mind||this.node.mindmap;
     }
     execute():boolean {
-        if(this.node.isRoot == true){
+        if(this.node.data.isRoot == true){
             return false;
         }
         this.node.clearCacheData();
@@ -253,7 +253,7 @@ export class CollapseNode extends Command{
        super('collapseNOde')
        this.node = node;
        this.node.mindmap.clearSelectNode();
-    
+
        this.node.refreshBox();
    }
    execute(){
@@ -324,9 +324,9 @@ export class ExpandNode extends Command{
 
     paste() {
         this.data.forEach((d:any, i:number) => {
-          
+
             var n = new INode(d, this.mind);
-          
+
             n.mindmap = this.mind;
             if (!d.isExpand) {
                 this.waitCollapse.push(n);
@@ -337,7 +337,7 @@ export class ExpandNode extends Command{
                 this.firstNode = n;
                 n.setPosition(0,0);
                 n.refreshBox();
-              
+
             }
             else {
                 var parent = this.mind.getNodeById(d.pid);
@@ -348,7 +348,7 @@ export class ExpandNode extends Command{
 
                 }
             }
-            
+
             if (i == this.data.length - 1) {
                 n.clearCacheData();
                 this.refresh(this.mind);
@@ -356,9 +356,3 @@ export class ExpandNode extends Command{
         });
     }
 }
-
-
-
-
-
-

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -1,4 +1,4 @@
-import MindMap from './mindmap' 
+import MindMap from './mindmap'
 import {MarkdownRenderer,normalizePath,TFile,parseLinktext,resolveSubpath} from 'obsidian'
 import {t} from '../lang/helpers'
 
@@ -7,11 +7,11 @@ export function keepLastIndex(dom:HTMLElement) {
     if ( window.getSelection ) { //ie11 10 9 ff safari
         dom.focus();  //ff
         var range = window.getSelection();
-        range.selectAllChildren(dom); 
-        range.collapseToEnd(); 
+        range.selectAllChildren(dom);
+        range.collapseToEnd();
     }
     // else if ( document.selection ) { //ie10 9 8 7 6 5
-    //     var range = document.selection.createRange(); 
+    //     var range = document.selection.createRange();
     //     range.moveToElementText(dom);
     //     range.collapse(false);
     //     range.select();
@@ -25,7 +25,8 @@ interface INode {
     mdText?:string;
     isRoot?:Boolean;
     children?:INode[];
-    
+    isEdit?:boolean;
+
 }
 
 interface BOX {
@@ -45,6 +46,7 @@ export class INodeData implements INode{
     isRoot?:Boolean;
     children?:INodeData[]
     expanded?:boolean;
+    isEdit?:boolean;
 }
 
 export default class Node {
@@ -61,13 +63,13 @@ export default class Node {
     isSelect:boolean = false;
     _oldText?:string;
     parent?:Node;
-    isRoot?:boolean;
+    //isRoot?:boolean;
     children:Node[]=[];
     boundingRect:any;
     direct?:string;
     isHide:boolean=false;
     stroke?:string;
-    isEdit:boolean=false;
+    //isEdit:boolean=false;
     _barDom:HTMLElement=null;
     data:any
     constructor( data:INode,mindMap?:MindMap){
@@ -96,9 +98,9 @@ export default class Node {
 
         if(this.data.isRoot){
             this.containEl.classList.add('mm-root');
-            this.isRoot = true;
+            this.data.isRoot = true;
         }else{
-            this.isRoot = false;
+            this.data.isRoot = false;
             this.containEl.classList.remove('mm-root');
         }
         this.parseText();
@@ -120,7 +122,7 @@ export default class Node {
             this.mindmap&&this.mindmap.emit('initNode',{});
             this._delay();
         });
-        
+
     }
 
     _delay(){
@@ -149,7 +151,7 @@ export default class Node {
                          markdownLink.classList.add('markdown-embed-link');
                          markdownLink.setAttribute('aria-label','Open link');
                          markdownLink.innerHTML = `<a data-href="${src}" href="${src}" class="internal-link" target="_blank" rel="noopener"><svg viewBox="0 0 100 100" class="link" width="20" height="20"><path fill="currentColor" stroke="currentColor" d="M74,8c-4.8,0-9.3,1.9-12.7,5.3l-10,10c-2.9,2.9-4.7,6.6-5.1,10.6C46,34.6,46,35.3,46,36c0,2.7,0.6,5.4,1.8,7.8l3.1-3.1 C50.3,39.2,50,37.6,50,36c0-3.7,1.5-7.3,4.1-9.9l10-10c2.6-2.6,6.2-4.1,9.9-4.1s7.3,1.5,9.9,4.1c2.6,2.6,4.1,6.2,4.1,9.9 s-1.5,7.3-4.1,9.9l-10,10C71.3,48.5,67.7,50,64,50c-1.6,0-3.2-0.3-4.7-0.8l-3.1,3.1c2.4,1.1,5,1.8,7.8,1.8c4.8,0,9.3-1.9,12.7-5.3 l10-10C90.1,35.3,92,30.8,92,26s-1.9-9.3-5.3-12.7C83.3,9.9,78.8,8,74,8L74,8z M62,36c-0.5,0-1,0.2-1.4,0.6l-24,24 c-0.5,0.5-0.7,1.2-0.6,1.9c0.2,0.7,0.7,1.2,1.4,1.4c0.7,0.2,1.4,0,1.9-0.6l24-24c0.6-0.6,0.8-1.5,0.4-2.2C63.5,36.4,62.8,36,62,36 z M36,46c-4.8,0-9.3,1.9-12.7,5.3l-10,10c-3.1,3.1-5,7.2-5.2,11.6c0,0.4,0,0.8,0,1.2c0,4.8,1.9,9.3,5.3,12.7 C16.7,90.1,21.2,92,26,92s9.3-1.9,12.7-5.3l10-10C52.1,73.3,54,68.8,54,64c0-2.7-0.6-5.4-1.8-7.8l-3.1,3.1 c0.5,1.5,0.8,3.1,0.8,4.7c0,3.7-1.5,7.3-4.1,9.9l-10,10C33.3,86.5,29.7,88,26,88s-7.3-1.5-9.9-4.1S12,77.7,12,74 c0-3.7,1.5-7.3,4.1-9.9l10-10c2.6-2.6,6.2-4.1,9.9-4.1c1.6,0,3.2,0.3,4.7,0.8l3.1-3.1C41.4,46.6,38.7,46,36,46L36,46z"></path></svg></a>`
-                       
+
                          el.appendChild(markdownEmbed);
                         //  markdownEmbed.appendChild(markdownHead);
                          markdownEmbed.appendChild(markdownContent);
@@ -206,8 +208,8 @@ export default class Node {
                   el.addClasses(["image-embed", "is-loaded"]);
                 }
               });
-              
-            //Possible causes of delay,code mathjax  
+
+            //Possible causes of delay,code mathjax
             var dom =this.contentEl.querySelector('code')|| this.contentEl.querySelector('.MathJax');
             if(dom){
                 setTimeout(()=>{
@@ -216,7 +218,7 @@ export default class Node {
                     this.mindmap&&this.mindmap.emit('renderEditNode',{});
                 },100);
             }
-            //image 
+            //image
             this.contentEl.querySelectorAll('img').forEach(element => {
                 element.onload = () => {
                         this.clearCacheData();
@@ -228,7 +230,7 @@ export default class Node {
                         this.refreshBox();
                         this.mindmap&&this.mindmap.emit('renderEditNode',{});
                 }
-    
+
                 element.setAttribute('draggble','false');
             });
 
@@ -238,7 +240,9 @@ export default class Node {
     select(){
         this.isSelect = true;
         this.containEl.setAttribute('draggable','true');
-        this.containEl.focus(); // set the dom to be focused
+        //if(this.mindmap.view.plugin.settings.focusOnMove) {
+            this.containEl.focus(); // set the dom to be focused
+        //}
         Object.assign(window,{
             myNode:this
         });
@@ -266,9 +270,9 @@ export default class Node {
         this.contentEl.setAttribute('contentEditable','true');
         this.contentEl.focus();
         this.mindmap.editNode = this;
-        this.isEdit = true;
+        this.data.isEdit = true;
         keepLastIndex(this.contentEl);
-     
+
         if (this.contentEl.innerText == t('Sub title')) {
             this.selectText();
         }
@@ -284,7 +288,7 @@ export default class Node {
         //     var range = document.body.createTextRange();
         //     range.moveToElementText(text);
         //     range.select();
-        // } 
+        // }
         if (window.getSelection) {
             var selection = window.getSelection();
             var range = document.createRange();
@@ -316,12 +320,12 @@ export default class Node {
 
         if(i_check)
         {// Check in case the pre-/suf-fix must be substracted
-            if( (l_selectedText.substring(0,2) == i_str_1)  || 
+            if( (l_selectedText.substring(0,2) == i_str_1)  ||
                 (l_selectedText.substring(0,2) == i_str_2)  )
             {// Prefix must be substracted
                 l_selectedText = l_selectedText.substring(i_str_1.length); // Remove leading prefix
 
-                if( (l_selectedText.substring(l_selectedText.length-2) == i_str_1)  || 
+                if( (l_selectedText.substring(l_selectedText.length-2) == i_str_1)  ||
                     (l_selectedText.substring(l_selectedText.length-2) == i_str_2)  )
                 {// Suffix must be substracted
                     l_selectedText = l_selectedText.substring(0,l_selectedText.length-i_str_1.length);
@@ -376,7 +380,7 @@ export default class Node {
 
         {// Check in case the pre-/suf-fix must be substracted
             if( (  ((l_selectedText.substring(0,1)=="*")    ||
-                    (l_selectedText.substring(0,1)=="_")    )   &&   
+                    (l_selectedText.substring(0,1)=="_")    )   &&
                 (l_selectedText.substring(0,2)!="**")           &&
                 (l_selectedText.substring(0,2)!="__")           )   ||
                 (l_selectedText.substring(0,3)=="***")              ||
@@ -384,7 +388,7 @@ export default class Node {
             {// Already italic
                 l_selectedText = l_selectedText.substring(1); // Remove leading prefix
 
-                if( (l_selectedText.substring(l_selectedText.length-1) == "*")  || 
+                if( (l_selectedText.substring(l_selectedText.length-1) == "*")  ||
                     (l_selectedText.substring(l_selectedText.length-1) == "_")  )
                 {// Suffix must be substracted
                     l_selectedText = l_selectedText.substring(0,l_selectedText.length-1);
@@ -423,7 +427,7 @@ export default class Node {
         }
         this.data.text = text;
         this.contentEl.innerText = '';
-        
+
         MarkdownRenderer.renderMarkdown(text,this.contentEl,this.mindmap.path||"",null).then(()=>{
             this.data.mdText = this.contentEl.innerHTML;
             this.refreshBox();
@@ -437,9 +441,9 @@ export default class Node {
                 oldText:this._oldText
             });
          }
-       
+
         this.contentEl.setAttribute('contentEditable','false');
-        this.isEdit = false;
+        this.data.isEdit = false;
 
         if(this.containEl.classList.contains('mm-edit-node')){
             this.containEl.classList.remove('mm-edit-node')
@@ -450,15 +454,12 @@ export default class Node {
     getLevel() {
         var level = 0, parent = this.parent;
 
-        if(this == this.mindmap.root){
-            return level;
-        }
-        
-        level++;
-        
-        while (parent && parent != this.mindmap.root) {
+        if(!this.data.isRoot){
             level++;
-            parent = parent.parent;
+            while (parent && parent != this.mindmap.root) {
+                level++;
+                parent = parent.parent;
+            }
         }
         return level;
     }
@@ -466,7 +467,7 @@ export default class Node {
 
     getIndex() {
         var l_index = 0;
-        if(!this.isRoot)
+        if(!this.data.isRoot)
         { l_index = this.parent.children.indexOf(this); }
         return l_index;
     }
@@ -560,7 +561,7 @@ export default class Node {
     getPreviousSibling() {
         var nodeIdx = this.getIndex();
         var returnedNode = (this as Node);
-        
+
         var searchedIdx = nodeIdx-1;
         if(nodeIdx == 0)
         {// This is the first sibling -> return the last one.
@@ -576,10 +577,10 @@ export default class Node {
             }
             // else: not the previous sibling
         })
-        
+
         return returnedNode;
     }
-    
+
     getNextSibling() {
         var nodeIdx = this.getIndex();
         var returnedNode = (this as Node);
@@ -709,7 +710,7 @@ export default class Node {
     }
 
     collapse(){
-        
+
         this.isExpand = false;
         function hide(node:Node) {
             node.hide();
@@ -729,6 +730,6 @@ export default class Node {
         }
     }
 
-   
+
 
 }

--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -24,7 +24,8 @@ interface Setting {
     exportMdModel?: string,
     headLevel: number,
     layoutDirect: string,
-    strokeArray?:any[]
+    strokeArray?:any[],
+    focusOnMove?: boolean
 }
 
 export default class MindMap {
@@ -194,7 +195,7 @@ export default class MindMap {
             if (isRoot) {
                 n.setPosition(x, y);
                 that.root = n;
-                n.isRoot = true;
+                n.data.isRoot = true;
             } else {
                 n.setPosition(0, 0);
                 p.children.push(n);
@@ -273,7 +274,7 @@ export default class MindMap {
             this.selectNode = null
         }
         if (this.editNode) {
-            if(this.editNode.isEdit){
+            if(this.editNode.data.isEdit){
                 this.editNode.cancelEdit();
             }
             this.editNode = null;
@@ -293,7 +294,7 @@ export default class MindMap {
         //     this.selectNode = null
         // }
         // if (this.editNode) {
-        //     if(this.editNode.isEdit){
+        //     if(this.editNode.data.isEdit){
         //         this.editNode.cancelEdit();
         //     }
         //     this.editNode = null;
@@ -367,7 +368,7 @@ export default class MindMap {
 
         if (this._tempNum == this._nodeNum) {
             this.refresh();
-            this.center();
+            //this.center();
         }
     }
 
@@ -416,7 +417,7 @@ export default class MindMap {
             // // Space
             // if (keyCode == 32) {
             //     var node = this.selectNode;
-            //     if (node && !node.isEdit) {
+            //     if (node && !node.data.isEdit) {
             //         e.preventDefault();
             //         e.stopPropagation();
             //         node.edit();
@@ -449,7 +450,7 @@ export default class MindMap {
         //     if (keyCode == 113) {
         //     // if (keyCode == 45) {
         //         var node = this.selectNode;
-        //         if (node && !node.isEdit) {
+        //         if (node && !node.data.isEdit) {
         //             e.preventDefault();
         //             e.stopPropagation();
         //             if (!node.isExpand) {
@@ -495,7 +496,7 @@ export default class MindMap {
             //     e.preventDefault();
             //     e.stopPropagation();
             //     if(node) {// A node is selected
-            //         if (!node.isEdit) {// Not editing a node => Add sibling node
+            //         if (!node.data.isEdit) {// Not editing a node => Add sibling node
             //             if (!node.isExpand) {
             //                 node.expand();
             //             }
@@ -520,7 +521,7 @@ export default class MindMap {
             //delete
             // if (keyCode == 46 || e.key == 'Delete' || e.key == 'Backspace') {
             //     var node = this.selectNode;
-            //     if (node && !node.isRoot && !node.isEdit) {
+            //     if (node && !node.data.isRoot && !node.data.isEdit) {
             //         e.preventDefault();
             //         e.stopPropagation();
             //         node.mindmap.execute("deleteNodeAndChild", { node });
@@ -536,7 +537,7 @@ export default class MindMap {
             //     e.stopPropagation();
             //     var node = this.selectNode;
             //     if(node) {
-            //         if (!node.isEdit) {// Not editing
+            //         if (!node.data.isEdit) {// Not editing
             //             if (!node.isExpand) {
             //                 node.expand();
             //             }
@@ -558,7 +559,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 var node = this.selectNode;
-                if (node && node.isEdit) {
+                if (node && node.data.isEdit) {
                     node.select();
                     node.mindmap.editNode = null;
                     node.cancelEdit();
@@ -573,7 +574,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 var node = this.selectNode;
-                if( node && !node.isEdit )
+                if( node && !node.data.isEdit )
                 {
                     var l_selectedNode = node;
                     while(  (this.selectNode == node)       &&
@@ -590,7 +591,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 var node = this.selectNode;
-                if( node && !node.isEdit )
+                if( node && !node.data.isEdit )
                 {
                     var l_selectedNode = node;
                     while(  (this.selectNode == node)       &&
@@ -607,7 +608,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var rootPos = this.root.getPosition();
                     var nodePos = node.getPosition();
                     if(rootPos.x > nodePos.x)
@@ -631,7 +632,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     var rootPos = this.root.getPosition();
                     var nodePos = node.getPosition();
                     if(rootPos.x < nodePos.x)
@@ -656,7 +657,7 @@ export default class MindMap {
                 e.stopPropagation();
 
                 if( (!this.selectNode)          ||
-                    (!this.selectNode.isEdit)   )
+                    (!this.selectNode.data.isEdit)   )
                 {// No edition: select root node
                     if(this.selectNode)
                     { this.selectNode.unSelect(); }
@@ -675,7 +676,7 @@ export default class MindMap {
             // }
             if ((keyCode == 191) || (keyCode == 111)) {
                 var node = this.selectNode;
-                if (node && !node.isEdit) {
+                if (node && !node.data.isEdit) {
                     if (node.isExpand) {
                         node.mindmap.execute('collapseNode', {
                             node
@@ -698,7 +699,7 @@ export default class MindMap {
             //         var l_prefix_2 = "__";
             //         var node = this.selectNode;
 
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in bold only the selected part
             //             var l_check_prefix = true;
             //             node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -726,7 +727,7 @@ export default class MindMap {
             //     if(this.selectNode) {
             //         var node = this.selectNode;
 
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in italics only the selected part
             //             node.setSelectedText_italic();
             //         }
@@ -789,8 +790,8 @@ export default class MindMap {
             //         this.root.select();
             //         node = this.selectNode;
             //     }
-            //     else if((!node.isEdit)  &&
-            //             (!node.isRoot)  )
+            //     else if((!node.data.isEdit)  &&
+            //             (!node.data.isRoot)  )
             //     {// The node can be moved
             //         var type='top';
             //         if(node.getIndex() == 0)
@@ -815,8 +816,8 @@ export default class MindMap {
             //         this.root.select();
             //         node = this.selectNode;
             //     }
-            //     else if((!node.isEdit)  &&
-            //             (!node.isRoot)  )
+            //     else if((!node.data.isEdit)  &&
+            //             (!node.data.isRoot)  )
             //     {// The node can be moved
             //         var type='down';
             //         if(node.getIndex() == node.parent.children.length-1)
@@ -905,10 +906,10 @@ export default class MindMap {
                 e.preventDefault();
                 e.stopPropagation();
 
-                if( (!this.selectNode)          ||
-                    (!this.selectNode.isEdit)   )
+                if( (!this.selectNode)              ||
+                    (!this.selectNode.data.isEdit)  )
                 {// No edition: select root node
-                    if(this.selectNode && !this.selectNode.isRoot)
+                    if(this.selectNode && !this.selectNode.data.isRoot)
                     {
                         this.selectNode.unSelect();
                         this.root.select();
@@ -971,7 +972,7 @@ export default class MindMap {
             //         var l_prefix_2 = l_prefix_1;
             //         var node = this.selectNode;
 
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in bold only the selected part
             //             var l_check_prefix = true;
             //             node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -998,7 +999,7 @@ export default class MindMap {
             //         var l_prefix_2 = l_prefix_1;
             //         var node = this.selectNode;
 
-            //         if(node.isEdit)
+            //         if(node.data.isEdit)
             //         {// A node is edited: set in bold only the selected part
             //             var l_check_prefix = true;
             //             node.setSelectedText(l_prefix_1, l_prefix_2, l_check_prefix);
@@ -1302,8 +1303,8 @@ export default class MindMap {
 
 
     _moveAsParent(node: INode) {
-        if( (!node.isEdit)          &&
-            (!node.isRoot)          &&
+        if( (!node.data.isEdit)     &&
+            (!node.data.isRoot)     &&
             (node.getLevel() > 1)   )
         {// The node can be moved
             this.moveNode(node, node.parent, 'down');
@@ -1314,8 +1315,8 @@ export default class MindMap {
 
 
     _moveAsChild(movedNode: INode, newParentNode: INode) {
-        if( (!movedNode.isEdit)  &&
-            (!movedNode.isRoot)  )
+        if( (!movedNode.data.isEdit)  &&
+            (!movedNode.data.isRoot)  )
         {// The node can be moved
             this.moveNode(movedNode, newParentNode, 'child-right');
         }
@@ -1326,7 +1327,7 @@ export default class MindMap {
 
 
     _toggleExpandNode(node: INode) {
-        if (node && !node.isEdit) {
+        if (node && !node.data.isEdit) {
             if (node.isExpand) {
                 node.mindmap.execute('collapseNode', {
                     node
@@ -1513,7 +1514,7 @@ export default class MindMap {
 
                  if(targetEl.closest('.mm-icon-delete-node')){
                     var selectNode = this.selectNode;
-                    if(!node.isRoot && selectNode){
+                    if(!node.data.isRoot && selectNode){
                        selectNode.mindmap.execute("deleteNodeAndChild", { node: selectNode });
                        this._menuDom.style.display='none';
                     }
@@ -1665,7 +1666,7 @@ export default class MindMap {
                 evt.preventDefault();
                 var dropNodeId = evt.target.closest('.mm-node').getAttribute('data-id');
                 var dropNode = this.getNodeById(dropNodeId);
-                if (this._dragNode.isRoot) {
+                if (this._dragNode.data.isRoot) {
 
                 } else {
                     this.moveNode(this._dragNode, dropNode,this._dragType);
@@ -1873,7 +1874,7 @@ export default class MindMap {
 
     moveNode(dragNode: INode, dropNode: INode, type:string, setInHistory: boolean = true) {
 
-        if (dragNode == dropNode || dragNode.isRoot) {
+        if (dragNode == dropNode || dragNode.data.isRoot) {
             return
         }
 
@@ -2001,10 +2002,14 @@ export default class MindMap {
     layout() {
         if (!this.mmLayout) {
             this.mmLayout = new Layout(this.root, this.setting.layoutDirect||'mind map', this.colors);
+            // Select and center on the mindmap's root when opening it
+            this.root.select();
+            this.centerOnNode(this.root);
             return;
         }
 
         this.mmLayout.layout(this.root, this.setting.layoutDirect || this.mmLayout.direct || 'mind map');
+
     }
 
     refresh() {
@@ -2062,7 +2067,8 @@ export default class MindMap {
             //this.containerEL.scrollTop = this.setting.canvasSize / 2 - h / 2 - 60 ;
             //this.containerEL.scrollLeft = this.setting.canvasSize / 2 - w / 2 + 30 ;
             this.containerEL.scrollTop  = pos_y - (h/2 - dim_y/2) + 90;
-            this.containerEL.scrollLeft = pos_x - (w/2 - dim_x/2) + 40;
+            //this.containerEL.scrollLeft = pos_x - (w/2 - dim_x/2) + 40;
+            this.containerEL.scrollLeft = pos_x - (w/2 - dim_x/2) + 200;
 
             this.scale(oldScale);
         }

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -138,33 +138,51 @@ export class MindMapSettingsTab extends PluginSettingTab {
                         });
                     }));
 
-             new Setting(containerEl)
-                    .setName(`${t('Stroke Array')}`)
-                    .setDesc(`${t('Stroke Array Desc')}`)
-                    .addText(text =>
-                        text
-                            .setValue(this.plugin.settings.strokeArray?.toString() || '')
-                            .setPlaceholder('Example: red,orange,blue ...')
-                            .onChange((value: string) => {
-                                //this.plugin.settings.strokeArray = value
-                                this.plugin.settings.strokeArray = value.split(',');
-                                this.plugin.saveData(this.plugin.settings);
-                                const mindmapLeaves = this.app.workspace.getLeavesOfType(mindmapViewType);
-                                
-                                mindmapLeaves.forEach((leaf) => {
-                                    var v = leaf.view as MindMapView;
-                                    //v.mindmap.setting.strokeArray = this.plugin.settings.strokeArray.split(',');
-                                    v.mindmap.setting.strokeArray = this.plugin.settings.strokeArray;
-                                    if( v.mindmap.mmLayout){
-                                        v.mindmap.mmLayout.colors=v.mindmap.setting.strokeArray;
-                                    }
-                                
-                                    v.mindmap.traverseBF((n: MyNode) => {
-                                        n.boundingRect = null;
-                                        n.refreshBox();
-                                    })
-                                    v.mindmap.refresh();
-                                });
-                            }));
+        new Setting(containerEl)
+            .setName(`${t('Stroke Array')}`)
+            .setDesc(`${t('Stroke Array Desc')}`)
+            .addText(text =>
+                text
+                    .setValue(this.plugin.settings.strokeArray?.toString() || '')
+                    .setPlaceholder('Example: red,orange,blue ...')
+                    .onChange((value: string) => {
+                        //this.plugin.settings.strokeArray = value
+                        this.plugin.settings.strokeArray = value.split(',');
+                        this.plugin.saveData(this.plugin.settings);
+                        const mindmapLeaves = this.app.workspace.getLeavesOfType(mindmapViewType);
+
+                        mindmapLeaves.forEach((leaf) => {
+                            var v = leaf.view as MindMapView;
+                            //v.mindmap.setting.strokeArray = this.plugin.settings.strokeArray.split(',');
+                            v.mindmap.setting.strokeArray = this.plugin.settings.strokeArray;
+                            if( v.mindmap.mmLayout){
+                                v.mindmap.mmLayout.colors=v.mindmap.setting.strokeArray;
+                            }
+
+                            v.mindmap.traverseBF((n: MyNode) => {
+                                n.boundingRect = null;
+                                n.refreshBox();
+                            })
+                            v.mindmap.refresh();
+                        });
+                    }));
+
+        new Setting(containerEl)
+            .setName('Display moved on current node')
+            .setDesc(
+                'If enabled, the mindmap view is centered on the current node when moving it',
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.focusOnMove).onChange((value) => {
+                        this.plugin.settings.focusOnMove = value;
+                        this.plugin.saveData(this.plugin.settings);
+
+                }),
+            );
+
+
+
+
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,4 +10,5 @@ export class MindMapSettings {
     exportMdModel?:string;
     //strokeArray?:string=''
     strokeArray?:any[];
+    focusOnMove:boolean;
 }


### PR DESCRIPTION
- Add a setting to avoid centering on the node that is being moved.
- Avoid unwanted mindmap center.
- Center on root node when opening the mindmap.
- "Center on node" displays the centered node more on the left.
- Use node.data.isEdit / node.data.isRoot instead of node.isEdit / node.isRoot.