### PR TITLE
当前文件无一级标题时候，使用文件名作为一级标题

### DIFF
--- a/main.js
+++ b/main.js
@@ -455,7 +455,8 @@ class Node {
     }
     parseText() {
         if (this.data.text.length === 0) {
-            this.data.text = "Sub title";
+            // this.data.text = "Sub title";
+            this.data.text = this.getFileName();
         }
         obsidian.MarkdownRenderer.renderMarkdown(this.data.text, this.contentEl, this.mindmap.path || "", null).then(() => {
             this.data.mdText = this.contentEl.innerHTML;
@@ -463,6 +464,14 @@ class Node {
             this.mindmap && this.mindmap.emit('initNode', {});
             this._delay();
         });
+    }
+    getFileName() {
+        const fileNameOnly = require('path').basename(this.mindmap.path);
+        // 获取文件的扩展名
+        const extension = require('path').extname(this.mindmap.path);
+        // 截图文件后缀
+        const fileNameWithoutExtension = fileNameOnly.substr(0, fileNameOnly.length - extension.length);
+        return fileNameWithoutExtension;
     }
     _delay() {
         //parse md

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -130,7 +130,7 @@ export default class Node {
         // 获取文件的扩展名
         const extension = require('path').extname(this.mindmap.path);
 
-        // 截图文件后缀
+        // 移除文件后缀
         const fileNameWithoutExtension = fileNameOnly.substr(0, fileNameOnly.length - extension.length);
 
         return fileNameWithoutExtension;

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -2,7 +2,6 @@ import MindMap from './mindmap'
 import {MarkdownRenderer,normalizePath,TFile,parseLinktext,resolveSubpath} from 'obsidian'
 import {t} from '../lang/helpers'
 
-
 export function keepLastIndex(dom:HTMLElement) {
     if ( window.getSelection ) { //ie11 10 9 ff safari
         dom.focus();  //ff
@@ -114,7 +113,8 @@ export default class Node {
 
     parseText(){
         if (this.data.text.length === 0){
-            this.data.text = "Sub title";
+            // this.data.text = "Sub title";
+            this.data.text = this.getFileName();
         }
         MarkdownRenderer.renderMarkdown( this.data.text ,this.contentEl,this.mindmap.path||"",null).then(()=>{
             this.data.mdText = this.contentEl.innerHTML;
@@ -122,7 +122,18 @@ export default class Node {
             this.mindmap&&this.mindmap.emit('initNode',{});
             this._delay();
         });
+    }
 
+    getFileName() {
+        const fileNameOnly = require('path').basename(this.mindmap.path);
+
+        // 获取文件的扩展名
+        const extension = require('path').extname(this.mindmap.path);
+
+        // 截图文件后缀
+        const fileNameWithoutExtension = fileNameOnly.substr(0, fileNameOnly.length - extension.length);
+
+        return fileNameWithoutExtension;
     }
 
     _delay(){

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -114,7 +114,7 @@ export default class Node {
     parseText(){
         if (this.data.text.length === 0){
             // this.data.text = "Sub title";
-            this.data.text = this.getFileName();
+            this.data.text = this.getCurrentFileName();
         }
         MarkdownRenderer.renderMarkdown( this.data.text ,this.contentEl,this.mindmap.path||"",null).then(()=>{
             this.data.mdText = this.contentEl.innerHTML;
@@ -124,7 +124,7 @@ export default class Node {
         });
     }
 
-    getFileName() {
+    getCurrentFileName() {
         const fileNameOnly = require('path').basename(this.mindmap.path);
 
         // 获取文件的扩展名


### PR DESCRIPTION
- 大多数情况下，markdown 的一级标题都是不写的，原因是创建笔记的时候文件名已经包含了足够多的语义，此时展示 Sub title 或者新节点感觉不是很合适
- 所以这里补充了一个自动获取文件名当做一级标题的逻辑
- 我对 ts 不是很熟悉，搜来的代码，如果有更好的实现或者觉得这个 PR 不符合该插件的设计，麻烦回复下，我可以仅本地自己使用

效果：
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/4969054e-6725-4802-94ac-aeddfbd63d08" />
