### PR TITLE
[feat] added frontmatter as root element title

### DIFF
--- a/main.js
+++ b/main.js
@@ -439,6 +439,7 @@ class Node {
         //this.containEl.textContent = this.data.text;
         this.initNodeBar();
         if (this.data.isRoot) {
+            this.containEl.setAttribute("title", this.data.tooltip);
             this.containEl.classList.add('mm-root');
             this.data.isRoot = true;
         }
@@ -8440,6 +8441,10 @@ class MindMap {
         //this.center();
         this.dispLevel = 0;
     }
+    updateFrontmatterTooltip(fm) {
+        this.frontmatter = fm;
+        this.data.tooltip = fm;
+    }
     setMenuIcon() {
         var addNodeDom = document.createElement('span');
         var deleteNodeDom = document.createElement('span');
@@ -8463,10 +8468,11 @@ class MindMap {
     init(collapsedIds) {
         var that = this;
         var data = this.data;
+        this.frontmatter;
         var x = this.setting.canvasSize / 2 - 60;
         var y = this.setting.canvasSize / 2 - 200;
         var waitCollapseNodes = [];
-        function initNode(d, isRoot, p) {
+        function initNode(d, isRoot, p, fm) {
             that._nodeNum++;
             var n = new Node(d, that);
             // if (collapsedIds && collapsedIds.includes(n.getId())) {
@@ -8479,6 +8485,9 @@ class MindMap {
             if (isRoot) {
                 n.setPosition(x, y);
                 that.root = n;
+                // if (fm) {
+                //     n.containEl.setAttribute("aria-label",fm);
+                // }
                 n.data.isRoot = true;
             }
             else {
@@ -8638,7 +8647,7 @@ class MindMap {
     }
     mindMapChange() {
         var _a;
-        //console.log(this.view)
+        // console.log(this.view)
         (_a = this.view) === null || _a === void 0 ? void 0 : _a.mindMapChange();
     }
     appFocusIn(evt) {
@@ -38385,6 +38394,7 @@ class MindMapView extends obsidian.TextFileView {
                     if (view.file) {
                         this.fileCache = this.app.metadataCache.getFileCache(view.file);
                         this.yamlString = this.getFrontMatter();
+                        this.mindmap.updateFrontmatterTooltip(this.yamlString);
                     }
                 }
                 this.mindmap.init();
@@ -38506,7 +38516,6 @@ class MindMapView extends obsidian.TextFileView {
         //       }
         //    })
         // })
-        super.onPaneMenu(menu, 'more-options');
     }
 }
 

--- a/src/MindMapView.ts
+++ b/src/MindMapView.ts
@@ -388,6 +388,7 @@ export class MindMapView extends TextFileView implements HoverParent {
           if (view.file) {
             this.fileCache = this.app.metadataCache.getFileCache(view.file);
             this.yamlString = this.getFrontMatter();
+            this.mindmap.updateFrontmatterTooltip(this.yamlString);
           }
         }
         this.mindmap.init();
@@ -529,8 +530,5 @@ export class MindMapView extends TextFileView implements HoverParent {
     //    })
 
     // })
-
-    super.onPaneMenu(menu,'more-options');
   }
-
 }

--- a/src/mindmap/INode.ts
+++ b/src/mindmap/INode.ts
@@ -2,7 +2,6 @@ import MindMap from './mindmap'
 import {MarkdownRenderer,normalizePath,TFile,parseLinktext,resolveSubpath} from 'obsidian'
 import {t} from '../lang/helpers'
 
-
 export function keepLastIndex(dom:HTMLElement) {
     if ( window.getSelection ) { //ie11 10 9 ff safari
         dom.focus();  //ff
@@ -41,12 +40,14 @@ interface BOX {
 export class INodeData implements INode{
     id:string;
     text:string;
+    tooltip?:string;
     pid?:string;
     mdText?:string;
     isRoot?:Boolean;
     children?:INodeData[]
     expanded?:boolean;
     isEdit?:boolean;
+
 }
 
 export default class Node {
@@ -72,7 +73,7 @@ export default class Node {
     //isEdit:boolean=false;
     _barDom:HTMLElement=null;
     data:any
-    constructor( data:INode,mindMap?:MindMap){
+    constructor( data:INode,mindMap?:MindMap ){
        this.data = data;
        this.mindmap = mindMap;
        this.initDom();
@@ -81,6 +82,7 @@ export default class Node {
     getId(){
         return this.data.id;
     }
+
 
     initDom(){
         this.containEl = document.createElement('div');
@@ -97,6 +99,7 @@ export default class Node {
         this.initNodeBar();
 
         if(this.data.isRoot){
+            this.containEl.setAttribute("title",this.data.tooltip);
             this.containEl.classList.add('mm-root');
             this.data.isRoot = true;
         }else{

--- a/src/mindmap/mindmap.ts
+++ b/src/mindmap/mindmap.ts
@@ -42,6 +42,7 @@ export default class MindMap {
     // selectedNodes?: INode[];
     setting: Setting;
     data: INodeData;
+    frontmatter?: string;
     drag?: boolean;
     startX?: number;
     startY?: number;
@@ -153,6 +154,11 @@ export default class MindMap {
         this.dispLevel=0;
     }
 
+    updateFrontmatterTooltip(fm: string){
+        this.frontmatter = fm;
+        this.data.tooltip = fm;
+    }
+
     setMenuIcon(){
         var addNodeDom = document.createElement('span');
         var deleteNodeDom = document.createElement('span');
@@ -177,11 +183,12 @@ export default class MindMap {
     init(collapsedIds?: string[]) {
         var that = this;
         var data = this.data;
+        var fm = this.frontmatter;
         var x = this.setting.canvasSize / 2 - 60;
         var y = this.setting.canvasSize / 2 - 200;
         var waitCollapseNodes:INode[]=[];
 
-        function initNode(d: INodeData, isRoot: boolean, p?: INode) {
+        function initNode(d: INodeData, isRoot: boolean, p?: INode, fm?: string) {
             that._nodeNum++;
             var n = new INode(d, that);
             // if (collapsedIds && collapsedIds.includes(n.getId())) {
@@ -195,6 +202,9 @@ export default class MindMap {
             if (isRoot) {
                 n.setPosition(x, y);
                 that.root = n;
+                // if (fm) {
+                //     n.containEl.setAttribute("aria-label",fm);
+                // }
                 n.data.isRoot = true;
             } else {
                 n.setPosition(0, 0);
@@ -379,7 +389,7 @@ export default class MindMap {
     }
 
     mindMapChange() {
-        //console.log(this.view)
+        // console.log(this.view)
         this.view?.mindMapChange();
     }
     appFocusIn(evt: FocusEvent){


### PR DESCRIPTION
This is a feature request, with a simple implementation included.

Currently, the frontmatter yaml is not visible while the document is rendered as a mindmap.
Ideally, this would be viewable somewhere, without returning to markdown format.

This implementation adds the yamlString as the root element's [title attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/title).